### PR TITLE
Bug in sigproc.py

### DIFF
--- a/lib/python/sigproc.py
+++ b/lib/python/sigproc.py
@@ -148,7 +148,7 @@ def samples_per_file(infile, hdrdict, hdrlen):
            return the number of (time-domain) samples in the file.
     """
     numbytes = os.stat(infile)[6] - hdrlen
-    bytes_per_sample = hdrdict['nchans'] * (hdrdict['nbits']/8)
+    bytes_per_sample = hdrdict['nchans'] * (hdrdict['nbits']/8.)
     if numbytes % bytes_per_sample:
         print "Warning!:  File does not appear to be of the correct length!"
     numsamples = numbytes / bytes_per_sample


### PR DESCRIPTION
Hi Scott,

I found a bug when using <8 bits filterbank files in sigproc.py. Can you check it ?

Greg
