### PR TITLE
Fixed bug on psrfits weights

### DIFF
--- a/src/psrfits.c
+++ b/src/psrfits.c
@@ -546,9 +546,9 @@ void read_PSRFITS_files(struct spectra_info *s)
     if (s->apply_scale==0)
         for (ii = 0 ; ii < s->num_channels * s->num_polns ; ii++)
             scales[ii] = 1.0;
-   if (s->apply_weight==0)
+    if (s->apply_weight==0)
         for (ii = 0 ; ii < s->num_channels ; ii++)
-            scales[ii] = 1.0;
+            weights[ii] = 1.0;
 }
 
 


### PR DESCRIPTION
I've fixed a type in psrfits.c that prevented the weights to work properly
