### PR TITLE
Increased the number of pulsars to be read in the catalog

### DIFF
--- a/include/database.h
+++ b/include/database.h
@@ -1,5 +1,5 @@
 /* Number of entries in PSR database */
-#define NP  2000
+#define NP  3000
 #define NBP 200
 
 /* This is a structure that contains the "normal" information in the database */

--- a/src/database.c
+++ b/src/database.c
@@ -27,6 +27,11 @@ int read_database(void)
    database = chkfopen(databasenm, "rb");
 
    while (chkfread(&pdata, sizeof(psrdata), 1, database)) {
+      if (np >= NP) {
+          printf("NP value set to small (%d) in $PRESTO/include/database.h\n", NP);
+          printf("Please increase it and recompile\n");
+          exit(-1);
+      }
       strncpy(pulsardata[np].jname, pdata.jname, 13);
       strncpy(pulsardata[np].bname, pdata.bname, 9);
       strncpy(pulsardata[np].alias, pdata.alias, 10);


### PR DESCRIPTION
Following the update of the pulsar catalog in the repo, there is now more than 2000 pulsars. I increased the number of pulsars in database.h (now 3000 instead of 2000) to prevent any segfault with accelsearch. I also added a check for it.
