### PR TITLE
Changes to sifting.py 

### DIFF
--- a/lib/python/sifting.py
+++ b/lib/python/sifting.py
@@ -225,7 +225,7 @@ class Candlist(object):
                     'Harmonic cand', 'DM problem', 'Good cands', 'Hits']
         colours = ['#FF0000', '#800000', '#008000', '#00FF00', \
                     '#00FFFF', '#0000FF', '#FF00FF', '#800080', 'r', 'k']
-        markers = ['o', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'x', ',']
+        markers = ['o', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'x', 's']
         zorders = [-2, -2, -2, -2, -2, -2, -2, -2, 0, 0]
         sizes = [50, 50, 50, 50, 50, 50, 50, 50, 100, 10]
         fixedsizes = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1]
@@ -249,7 +249,7 @@ class Candlist(object):
                 else:
                     plt.scatter(freqs, dms, s=8+sigmas**1.7, lw=lw, \
                                 c=colour, marker=marker, alpha=0.7, zorder=zorder)
-            handles.append(plt.scatter([], [], s=size, c=colour, \
+            handles.append(plt.scatter([0], [0], s=size, c=colour, \
                                     marker=marker, alpha=0.7))
 
         fig.legend(handles, labels, 'lower center', \


### PR DESCRIPTION
Hi Scott. Heres a few changes to sifting.py that make it play better with older versions of matplotlib (which don't like plotting empty lists and the pixel (',') marker). There are also two commits that make the candlist iterable and return an empty list when there are no cands to make it more consistent with the old API (pre-Patrick's rewite)

Paul
