### PR TITLE
Sifting

### DIFF
--- a/lib/python/sifting.py
+++ b/lib/python/sifting.py
@@ -1152,7 +1152,7 @@ def candlist_from_candfile(filename):
     return Candlist(cands)
 
 
-def read_candidates(filenms, prelim_reject=True):
+def read_candidates(filenms, prelim_reject=True, track=False):
     """Read in accelsearch candidates from the test ACCEL files.
         Return a Candlist object of Candidate instances.
 
@@ -1160,9 +1160,11 @@ def read_candidates(filenms, prelim_reject=True):
             filenms: A list of files to read candidates from.
             prelim_reject: If True, perform preliminary rejection of
                 candidates. (Default: True)
+            track: If True, keep track of bad/duplicate candidates.
+                (Default: False)
 
     """
-    candlist = Candlist()
+    candlist = Candlist(trackbad=track, trackdupes=track)
     numfiles = len(filenms)
     if filenms:
         print "\nReading candidates from %d files...." % len(filenms)


### PR DESCRIPTION
Here are updates to sifting:
- it is less memory-hungry
- plots have been updated, and should work with older versions of matplotlib
- too-low-DM candidates shouldn't pass through sifting
- tracking of bad/duplicate candidates is off by default now, but can be turned on with an argument to read_candidates
- the text output format now includes sigma for all hits (in addition to dm and snr)

Patrick
