### PR TITLE
Added dmprec flag to prepsubband to allow the specification of DM precision in filenames ranging from 2-4.

### DIFF
--- a/clig/prepsubband.1
+++ b/clig/prepsubband.1
@@ -11,7 +11,7 @@
 .\" it edited by clig, remove the respective pair of cligPart-lines.
 .\"
 .\" cligPart TITLE
-.TH "prepsubband" 1 "31Aug12" "Clig-manuals" "Programmer's Manual"
+.TH "prepsubband" 1 "08Apr14" "Clig-manuals" "Programmer's Manual"
 .\" cligPart TITLE end
 
 .\" cligPart NAME
@@ -51,6 +51,7 @@ prepsubband \- Converts a raw radio data file into many de-dispersed time-series
 [-numdms numdms]
 [-nsub nsub]
 [-downsamp downsamp]
+[-dmprec dmprec]
 [-mask maskfile]
 infile ...
 .\" cligPart SYNOPSIS end
@@ -153,6 +154,12 @@ The number of neighboring bins to co-add,
 1 Int value between 1 and 128.
 .br
 Default: `1'
+.IP -dmprec
+The number of decimals in the precision of the DM in the filename.,
+.br
+1 Int value between 2 and 4.
+.br
+Default: `2'
 .IP -mask
 File containing masking information to use,
 .br

--- a/clig/prepsubband_cmd.cli
+++ b/clig/prepsubband_cmd.cli
@@ -50,6 +50,8 @@ Int     -nsub   nsub    {The number of sub-bands to use} \
 	-r 1 1024 -d 32
 Int     -downsamp downsamp {The number of neighboring bins to co-add} \
 	-r 1 128 -d 1
+Int     -dmprec dmprec  {The number of decimals in the precision of the DM in the filename.} \
+        -r 2 4 -d 2
 String -mask    maskfile {File containing masking information to use}
 
 # Rest of command line:

--- a/docs/prepsubband.1
+++ b/docs/prepsubband.1
@@ -11,7 +11,7 @@
 .\" it edited by clig, remove the respective pair of cligPart-lines.
 .\"
 .\" cligPart TITLE
-.TH "prepsubband" 1 "31Aug12" "Clig-manuals" "Programmer's Manual"
+.TH "prepsubband" 1 "08Apr14" "Clig-manuals" "Programmer's Manual"
 .\" cligPart TITLE end
 
 .\" cligPart NAME
@@ -51,6 +51,7 @@ prepsubband \- Converts a raw radio data file into many de-dispersed time-series
 [-numdms numdms]
 [-nsub nsub]
 [-downsamp downsamp]
+[-dmprec dmprec]
 [-mask maskfile]
 infile ...
 .\" cligPart SYNOPSIS end
@@ -153,6 +154,12 @@ The number of neighboring bins to co-add,
 1 Int value between 1 and 128.
 .br
 Default: `1'
+.IP -dmprec
+The number of decimals in the precision of the DM in the filename.,
+.br
+1 Int value between 2 and 4.
+.br
+Default: `2'
 .IP -mask
 File containing masking information to use,
 .br

--- a/include/prepsubband_cmd.h
+++ b/include/prepsubband_cmd.h
@@ -89,6 +89,10 @@ typedef struct s_Cmdline {
   char downsampP;
   int downsamp;
   int downsampC;
+  /***** -dmprec: The number of decimals in the precision of the DM in the filename. */
+  char dmprecP;
+  int dmprec;
+  int dmprecC;
   /***** -mask: File containing masking information to use */
   char maskfileP;
   char* maskfile;

--- a/src/prepsubband.c
+++ b/src/prepsubband.c
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
    int numdiffbins = 0, *diffbins = NULL, *diffbinptr = NULL;
    int *idispdt;
    char *datafilenm;
+   int dmprecision=2;
    struct spectra_info s;
    infodata idata;
    mask obsmask;
@@ -81,6 +82,7 @@ int main(int argc, char *argv[])
 
    cmd = parseCmdline(argc, argv);
    spectra_info_set_defaults(&s);
+   dmprecision=cmd->dmprec;
    s.filenames = cmd->argv;
    s.num_files = cmd->argc;
    s.clip_sigma = cmd->clip;
@@ -216,7 +218,7 @@ int main(int argc, char *argv[])
       for (ii = 0; ii < cmd->numdms; ii++) {
          dms[ii] = cmd->lodm + ii * cmd->dmstep;
          avgdm += dms[ii];
-         sprintf(datafilenm, "%s_DM%.2f.dat", cmd->outfile, dms[ii]);
+         sprintf(datafilenm, "%s_DM%.*f.dat", cmd->outfile, dmprecision,dms[ii]);
          outfiles[ii] = chkfopen(datafilenm, "wb");
          printf("   '%s'\n", datafilenm);
       }
@@ -240,9 +242,9 @@ int main(int argc, char *argv[])
       maxdm = cmd->subdm;
       outfiles = (FILE **) malloc(cmd->nsub * sizeof(FILE *));
       num_places = (int) ceil(log10(cmd->nsub));
-      sprintf(format_str, "%%s_DM%%.2f.sub%%0%dd", num_places);
+      sprintf(format_str, "%%s_DM%%.*f.sub%%0%dd", num_places);
       for (ii = 0; ii < cmd->nsub; ii++) {
-         sprintf(datafilenm, format_str, cmd->outfile, avgdm, ii);
+         sprintf(datafilenm, format_str, cmd->outfile, dmprecision, avgdm, ii);
          outfiles[ii] = chkfopen(datafilenm, "wb");
          printf("   '%s'\n", datafilenm);
       }
@@ -618,9 +620,9 @@ int main(int argc, char *argv[])
          idata.mjd_f = baryepoch - idata.mjd_i;
       }
       if (cmd->subP)
-         sprintf(idata.name, "%s_DM%.2f.sub", cmd->outfile, dms[ii]);
+         sprintf(idata.name, "%s_DM%.*f.sub", cmd->outfile, dmprecision, dms[ii]);
       else
-         sprintf(idata.name, "%s_DM%.2f", cmd->outfile, dms[ii]);
+         sprintf(idata.name, "%s_DM%.*f", cmd->outfile, dmprecision, dms[ii]);
       writeinf(&idata);
    }
 
@@ -631,7 +633,7 @@ int main(int argc, char *argv[])
 
       for (ii = 0; ii < cmd->numdms; ii++) {
          fclose(outfiles[ii]);
-         sprintf(datafilenm, "%s_DM%.2f.dat", cmd->outfile, dms[ii]);
+         sprintf(datafilenm, "%s_DM%.*f.dat", cmd->outfile, dmprecision, dms[ii]);
          outfiles[ii] = chkfopen(datafilenm, "rb+");
       }
       for (ii = 0; ii < idata.numonoff; ii++) {

--- a/src/prepsubband_cmd.c
+++ b/src/prepsubband_cmd.c
@@ -102,6 +102,10 @@ static Cmdline cmd = {
   /* downsampP = */ 1,
   /* downsamp = */ 1,
   /* downsampC = */ 1,
+  /***** -dmprec: The number of decimals in the precision of the DM in the filename. */
+  /* dmprecP = */ 1,
+  /* dmprec = */ 2,
+  /* dmprecC = */ 1,
   /***** -mask: File containing masking information to use */
   /* maskfileP = */ 0,
   /* maskfile = */ (char*)0,
@@ -1075,6 +1079,18 @@ showOptionValues(void)
     }
   }
 
+  /***** -dmprec: The number of decimals in the precision of the DM in the filename. */
+  if( !cmd.dmprecP ) {
+    printf("-dmprec not found.\n");
+  } else {
+    printf("-dmprec found:\n");
+    if( !cmd.dmprecC ) {
+      printf("  no values\n");
+    } else {
+      printf("  value = `%d'\n", cmd.dmprec);
+    }
+  }
+
   /***** -mask: File containing masking information to use */
   if( !cmd.maskfileP ) {
     printf("-mask not found.\n");
@@ -1101,7 +1117,7 @@ showOptionValues(void)
 void
 usage(void)
 {
-  fprintf(stderr,"%s","   -o outfile [-pkmb] [-gmrt] [-bcpm] [-spigot] [-filterbank] [-psrfits] [-noweights] [-noscales] [-nooffsets] [-wapp] [-window] [-numwapps numwapps] [-if ifs] [-clip clip] [-noclip] [-invert] [-zerodm] [-runavg] [-sub] [-subdm subdm] [-numout numout] [-nobary] [-DE405] [-lodm lodm] [-dmstep dmstep] [-numdms numdms] [-nsub nsub] [-downsamp downsamp] [-mask maskfile] [--] infile ...\n");
+  fprintf(stderr,"%s","   -o outfile [-pkmb] [-gmrt] [-bcpm] [-spigot] [-filterbank] [-psrfits] [-noweights] [-noscales] [-nooffsets] [-wapp] [-window] [-numwapps numwapps] [-if ifs] [-clip clip] [-noclip] [-invert] [-zerodm] [-runavg] [-sub] [-subdm subdm] [-numout numout] [-nobary] [-DE405] [-lodm lodm] [-dmstep dmstep] [-numdms numdms] [-nsub nsub] [-downsamp downsamp] [-dmprec dmprec] [-mask maskfile] [--] infile ...\n");
   fprintf(stderr,"%s","      Converts a raw radio data file into many de-dispersed time-series (including barycentering).\n");
   fprintf(stderr,"%s","             -o: Root of the output file names\n");
   fprintf(stderr,"%s","                 1 char* value\n");
@@ -1151,11 +1167,14 @@ usage(void)
   fprintf(stderr,"%s","      -downsamp: The number of neighboring bins to co-add\n");
   fprintf(stderr,"%s","                 1 int value between 1 and 128\n");
   fprintf(stderr,"%s","                 default: `1'\n");
+  fprintf(stderr,"%s","        -dmprec: The number of decimals in the precision of the DM in the filename.\n");
+  fprintf(stderr,"%s","                 1 int value between 2 and 4\n");
+  fprintf(stderr,"%s","                 default: `2'\n");
   fprintf(stderr,"%s","          -mask: File containing masking information to use\n");
   fprintf(stderr,"%s","                 1 char* value\n");
   fprintf(stderr,"%s","         infile: Input data file name.  If the data is not in a known raw format, it should be a single channel of single-precision floating point data.  In this case a '.inf' file with the same root filename must also exist (Note that this means that the input data file must have a suffix that starts with a period)\n");
   fprintf(stderr,"%s","                 1...16384 values\n");
-  fprintf(stderr,"%s","  version: 31Aug12\n");
+  fprintf(stderr,"%s","  version: 08Apr14\n");
   fprintf(stderr,"%s","  ");
   exit(EXIT_FAILURE);
 }
@@ -1366,6 +1385,16 @@ parseCmdline(int argc, char **argv)
       cmd.downsampC = i-keep;
       checkIntLower("-downsamp", &cmd.downsamp, cmd.downsampC, 128);
       checkIntHigher("-downsamp", &cmd.downsamp, cmd.downsampC, 1);
+      continue;
+    }
+
+    if( 0==strcmp("-dmprec", argv[i]) ) {
+      int keep = i;
+      cmd.dmprecP = 1;
+      i = getIntOpt(argc, argv, i, &cmd.dmprec, 1);
+      cmd.dmprecC = i-keep;
+      checkIntLower("-dmprec", &cmd.dmprec, cmd.dmprecC, 4);
+      checkIntHigher("-dmprec", &cmd.dmprec, cmd.dmprecC, 2);
       continue;
     }
 


### PR DESCRIPTION
Here is a patch to allow additional precision in the filenames created by prepsubband. It only allows values from 2 to 4 and the default is 2, so if -dmprec is not used on the command line, it should act as it always has.

Kevin 
