### PR TITLE
No crash with event files

### DIFF
--- a/bin/get_TOAs.py
+++ b/bin/get_TOAs.py
@@ -187,9 +187,6 @@ if __name__ == '__main__':
     timestep_day = timestep_sec / SECPERDAY
     fold.epoch = fold.epochi+fold.epochf
 
-#    print dir(fold)
-#    print fold_pfd
-
     # Over-ride the DM that was used during the fold
     if (DM!=0.0):
         fold_pfd.bestdm = DM


### PR DESCRIPTION
When using the -e switch, the program did not find the subdelays2 array, and crashed. This commit solves the problem.
