### PR TITLE
Update sigproc_fb.c

### DIFF
--- a/src/sigproc_fb.c
+++ b/src/sigproc_fb.c
@@ -112,7 +112,7 @@ void get_telescope_name(int telescope_id, struct spectra_info *s)
         s->beam_FWHM = default_beam;
         break;
     case 10:
-        strcpy(s->telescope, "UTR-2");
+        strcpy(s->telescope, "SRT");
         s->beam_FWHM = default_beam;
         break;
     case 11:


### PR DESCRIPTION
SIGPROC will use the code 10 for SRT (https://github.com/SixByNine/sigproc/blob/master/src/aliases.c), so this change is made for consistency