### PR TITLE
Do not read in padding from end of timeseries in single_pulse_search.py

### DIFF
--- a/bin/single_pulse_search.py
+++ b/bin/single_pulse_search.py
@@ -349,9 +349,9 @@ def main():
                 offregions = zip([x[1] for x in info.onoff[:-1]],
                                  [x[0] for x in info.onoff[1:]])
 
-            # If last break spans to end of file, don't read it in (its just padding)
-            if offregions[-1][1] == N - 1:
-                N = offregions[-1][0] + 1
+                # If last break spans to end of file, don't read it in (its just padding)
+                if offregions[-1][1] == N - 1:
+                    N = offregions[-1][0] + 1
 
             outfile = open(filenmbase+'.singlepulse', mode='w')
 

--- a/bin/single_pulse_search.py
+++ b/bin/single_pulse_search.py
@@ -348,6 +348,11 @@ def main():
             if info.breaks:
                 offregions = zip([x[1] for x in info.onoff[:-1]],
                                  [x[0] for x in info.onoff[1:]])
+
+            # If last break spans to end of file, don't read it in (its just padding)
+            if offregions[-1][1] == N - 1:
+                N = offregions[-1][0] + 1
+
             outfile = open(filenmbase+'.singlepulse', mode='w')
 
             # Compute the file length in detrendlens


### PR DESCRIPTION
Hi Scott,

I've made a small modification to single_pulse_search.py to ignore the padding when reading in timeseries. I've tested it and it seems to work well.

Paul