### PR TITLE
Redirect 'which' errors to /dev/null when checking for pstoimg

### DIFF
--- a/src/prepfold_plot.c
+++ b/src/prepfold_plot.c
@@ -1273,7 +1273,7 @@ void prepfold_plot(prepfoldinfo * search, plotflags * flags, int xwin, float *pp
           char *command;
           command = (char *)malloc(2 * strlen(search->pgdev) + 60);
           // First test to see if pstoimg exists
-          strcpy(command, "which pstoimg > /dev/null");
+          strcpy(command, "which pstoimg >& /dev/null");
           retval = system(command);
           // If the command exists, then convert the .ps to .png
           if (retval==0) {


### PR DESCRIPTION
Hi Scott,

Here is a very minor change to the check for pstoimg. On guillimin when 'which' is ran and it doesn't find anything it prints a message to stderr. This was causing successful PALFA pipeline jobs to be marked as failed, since they had non-empty error logs.

Paul