### PR TITLE
Tim2dat inf polycos

### DIFF
--- a/bin/tim2dat.py
+++ b/bin/tim2dat.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+import os
+import os.path
+import argparse
+import sys
+import getpass
+import re
+
+import numpy as np
+
+import sigproc
+import infodata
+import psr_utils
+
+BLOCKSIZE = 10000  # Amount of data to copy at a time
+                   # from input file to output file (in samples)
+RADTOHOUR = 12.0/np.pi
+
+
+def rad_to_hmsstr(rad):
+    """Convert radians to HH:MM:SS.SS sexigesimal string.
+    """
+    sign = np.sign(rad)
+    hour = np.abs(rad)*RADTOHOUR
+    # Add small value so results isn't affected by machine precision.
+    hour += 1e-12
+    h = int(hour)
+    min = (hour-h)*60.0
+    m = int(min)
+    s = (min-m)*60.0
+    if sign == -1:
+        sign = "-"
+    else:
+        sign = ""
+    if (s >= 9.9995):
+        hmsstr = "%s%.2d:%.2d:%.4f" % (sign, h, m, s)
+    else:
+        hmsstr = "%s%.2d:%.2d:0%.4f" % (sign, h, m, s)
+    return hmsstr
+
+
+def rad_to_dmsstr(rad):
+    """Convert radians to DD:MM:SS.SS sexigesimal string.
+    """
+    sign = np.sign(rad)
+    deg = np.rad2deg(np.abs(rad))
+    # Add small value so results isn't affected by machine precision.
+    deg += 1e-12
+    d = int(deg)
+    min = (deg-d)*60.0
+    m = int(min)
+    s = (min-m)*60.0
+    if sign == -1:
+        sign = "-"
+    else:
+        sign = ""
+    if (s >= 9.9995):
+        dmsstr = "%s%.2d:%.2d:%.4f" % (sign, d, m, s)
+    else:
+        dmsstr = "%s%.2d:%.2d:0%.4f" % (sign, d, m, s)
+    return dmsstr
+
+
+def write_inf_file(datfn, hdr, hdrlen):
+    """Write a PRESTO .inf file given a .dat file and
+        a dictionary of SIGPROC-style header values.
+
+        Inputs:
+            datfn: The PRESTO .dat file to write a .inf file for.
+            hdr: A dictionary of SIGPROC header values, as produced
+                by PRESTO's sigproc.read_header.
+            hdrlen: Length (in bytes) of SIGPROC file's header.
+
+        Output:
+            inffn: The corresponding .inf file that is created.
+    """
+    if not datfn.endswith(".dat"):
+        raise ValueError("Was expecting a file name ending with '.dat'. "
+                         "Got: %s" % datfn)
+
+    size = os.path.getsize(datfn)
+    if size % 4:
+        raise ValueError("Bad size (%d bytes) for PRESTO .dat file (%s)"
+                         "Should be multiple of 4 because samples are "
+                         "32-bit floats." % (size, datfn))
+    N = size / 4  # Number of samples
+    rarad = sigproc.ra2radians(hdr['src_raj'])
+    decrad = sigproc.dec2radians(hdr['src_dej'])
+
+    inffn = datfn[:-4]+".inf"
+    with open(inffn, 'w') as ff:
+        ff.write(" Data file name without suffix          =  %s\n" %
+                 os.path.basename(datfn))
+        ff.write(" Telescope used                         =  %s\n" %
+                 sigproc.ids_to_telescope[hdr['telescope_id']])
+        ff.write(" Instrument used                        =  %s\n" %
+                 sigproc.ids_to_machine.get('machine_id', 'UNKNOWN'))
+        ff.write(" Object being observed                  =  %s\n" %
+                 hdr['source_name'])
+        ff.write(" J2000 Right Ascension (hh:mm:ss.ssss)  =  %s\n" %
+                 rad_to_hmsstr(rarad))
+        ff.write(" J2000 Declination     (dd:mm:ss.ssss)  =  %s\n" %
+                 rad_to_dmsstr(decrad))
+        ff.write(" Data observed by                       =  UNKNOWN\n")
+        ff.write(" Epoch of observation (MJD)             =  %05.15f\n" %
+                 hdr['tstart'])
+        ff.write(" Barycentered?           (1=yes, 0=no)  =  %d\n" %
+                 hdr['barycentric'])
+        ff.write(" Number of bins in the time series      =  %d\n" % N)
+        ff.write(" Width of each time series bin (sec)    =  %.15g\n" %
+                 hdr['tsamp'])
+        ff.write(" Orbit removed?          (1=yes, 0=no)  =  %d\n" %
+                 hdr['pulsarcentric'])
+        ff.write(" Dispersion measure (cm-3 pc)           =  %f\n" %
+                 hdr['refdm'])
+        ff.write(" Central freq of low channel (Mhz)      =  %f\n" %
+                 hdr['fch1'])
+        ff.write(" Total bandwidth (Mhz)                  =  %f\n" %
+                 (hdr['nchans']*hdr['foff']))
+        ff.write(" Number of channels                     =  %d\n" %
+                 hdr['nchans'])
+        ff.write(" Channel bandwidth (Mhz)                =  %d\n" %
+                 hdr['foff'])
+        ff.write(" Data analyzed by                       =  %s\n" %
+                 getpass.getuser())
+        ff.write(" Any additional notes:\n"
+                 "    File converted from SIGPROC .tim time series\n"
+                 "    with PRESTO's tim2dat.py, written by Patrick Lazarus")
+    return inffn
+
+
+def convert_tim_to_dat(tim):
+    """Convert a SIGPROC time series .tim file to a
+        PRESTO .dat time series
+
+        Input:
+            tim: The SIGPROC .tim time series file to convert.
+
+        Output:
+            datfn: The PRESTO .dat time series file
+    """
+    if not tim.endswith(".tim"):
+        raise ValueError("Was expecting a file name ending with '.tim'. "
+                         "Got: %s" % tim)
+    path, fn = os.path.split(tim)
+    basenm = fn[:-4]
+    outfn = os.path.join(path, basenm+".dat")
+    hdr, hdrlen = sigproc.read_header(tim)
+
+    N = sigproc.samples_per_file(tim, hdr, hdrlen)
+    Ndone = 0
+    status = -1
+    with open(tim, 'rb') as inff, open(outfn, 'wb') as outff:
+        inff.seek(hdrlen)
+
+        data = np.fromfile(inff, dtype='float32', count=BLOCKSIZE)
+        while data.size:
+            data.tofile(outff)
+            Ndone += data.size
+            data = np.fromfile(inff, dtype='float32', count=BLOCKSIZE)
+            newstatus = int(100.0*Ndone/N)
+            if newstatus > status:
+                sys.stdout.write(" %d %%\r" % newstatus)
+                sys.stdout.flush()
+                status = newstatus
+    return outfn
+
+
+def main():
+    for tim in args.timfiles:
+        print "Working on %s" % tim
+
+        if args.write_dat:
+            try:
+                datfn = convert_tim_to_dat(tim)
+                print "    Wrote PRESTO time series: %s" % datfn
+            except ValueError, e:
+                sys.stderr.write("Error encountered when converting on %s" % tim)
+                sys.stderr.write(str(e))
+        else:
+            datfn = re.sub(r'\.tim$', '.dat', tim, count=1)
+
+        hdr, hdrlen = sigproc.read_header(tim)
+        inffn = write_inf_file(datfn, hdr, hdrlen)
+        print "    Wrote info data: %s" % inffn
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("timfiles", nargs="+",
+                        help="SIGPROC .tim time series files to convert to "
+                             "PRESTO *.dat time series files")
+    parser.add_argument("--inf-only", dest='write_dat', action='store_false',
+                        help="Only produce the .inf file, not the .dat file."
+                             "(Default: create both .dat and .inf files)")
+    args = parser.parse_args()
+    main()

--- a/lib/python/infodata.py
+++ b/lib/python/infodata.py
@@ -71,3 +71,73 @@ class infodata:
                 self.analyzer = line.split("=")[-1].strip()
                 continue
             
+    def to_file(self, inffn, notes=None):
+        if not inffn.endswith(".inf"):
+            raise ValueError("PRESTO info files must end with '.inf'. "
+                             "Got: %s" % inffn)
+        with open(inffn, 'w') as ff:
+            if hasattr(self, 'basenm'):
+                ff.write(" Data file name without suffix          =  %s\n" %
+                         self.basenm)
+            if hasattr(self, 'telescope'):
+                ff.write(" Telescope used                         =  %s\n" %
+                         self.telescope)
+            if hasattr(self, 'instrument'):
+                ff.write(" Instrument used                        =  %s\n" %
+                         self.instrument)
+            if hasattr(self, 'object'):
+                ff.write(" Object being observed                  =  %s\n" %
+                         self.object)
+            if hasattr(self, 'RA'):
+                ff.write(" J2000 Right Ascension (hh:mm:ss.ssss)  =  %s\n" %
+                         self.RA)
+            if hasattr(self, 'DEC'):
+                ff.write(" J2000 Declination     (dd:mm:ss.ssss)  =  %s\n" %
+                         self.DEC)
+            if hasattr(self, 'observer'):
+                ff.write(" Data observed by                       =  %s\n" %
+                         self.observer)
+            if hasattr(self, 'epoch'):
+                ff.write(" Epoch of observation (MJD)             =  %05.15f\n" %
+                         self.epoch)
+            if hasattr(self, 'bary'):
+                ff.write(" Barycentered?           (1=yes, 0=no)  =  %d\n" %
+                         self.bary)
+            if hasattr(self, 'N'):
+                ff.write(" Number of bins in the time series      =  %d\n" %
+                         self.N)
+            if hasattr(self, 'dt'):
+                ff.write(" Width of each time series bin (sec)    =  %.15g\n" %
+                         self.dt)
+            if hasattr(self, 'breaks') and self.breaks:
+                ff.write(" Any breaks in the data? (1 yes, 0 no)  =  1\n")
+                if hasattr(self, 'onoff'):
+                    for ii, (on, off) in enumerate(self.onoff, 1):
+                        ff.write(" On/Off bin pair #%3d                   =  %d, %d\n" %
+                                 (ii, on, off))
+            else:
+                ff.write(" Any breaks in the data? (1 yes, 0 no)  =  0\n")
+            if hasattr(self, 'DM'):
+                ff.write(" Dispersion measure (cm-3 pc)           =  %f\n" %
+                         self.DM)
+            if hasattr(self, 'lofreq'):
+                ff.write(" Central freq of low channel (Mhz)      =  %f\n" %
+                         self.lofreq)
+            if hasattr(self, 'BW'):
+                ff.write(" Total bandwidth (Mhz)                  =  %f\n" %
+                         self.BW)
+            if hasattr(self, 'numchan'):
+                ff.write(" Number of channels                     =  %d\n" %
+                         self.numchan)
+            if hasattr(self, 'chan_width'):
+                ff.write(" Channel bandwidth (Mhz)                =  %d\n" %
+                         self.chan_width)
+            if hasattr(self, 'analyzer'):
+                ff.write(" Data analyzed by                       =  %s\n" %
+                         self.analyzer)
+            if hasattr(self, 'deorbited'):
+                ff.write(" Orbit removed?          (1=yes, 0=no)  =  %d\n" %
+                         self.deorbited)
+            ff.write(" Any additional notes:\n")
+            if notes is not None:
+                ff.write("    %s\n" % notes.strip())

--- a/lib/python/polycos.py
+++ b/lib/python/polycos.py
@@ -96,7 +96,8 @@ class polyco:
                 nlines = self.numcoeff//3
                 for coeffnum in range(len(sl)):
                     self.coeffs[nlines*3+coeffnum] = float(sl[coeffnum].replace('D', 'E'))
-    
+            self.phasepoly = Num.polynomial.polynomial.Polynomial(self.coeffs)
+
     def phase(self, mjdi, mjdf):
         """
         self.phase(mjdi, mjdf):
@@ -111,9 +112,10 @@ class polyco:
             given integer and fractional MJD.
         """
         DT = ((mjdi-self.TMIDi)+(mjdf-self.TMIDf))*1440.0
-        phase = self.coeffs[self.numcoeff-1]
-        for ii in range(self.numcoeff-1, 0, -1):
-            phase = DT*phase + self.coeffs[ii-1]
+        phase = self.phasepoly(DT)
+        #phase = self.coeffs[self.numcoeff-1]
+        #for ii in range(self.numcoeff-1, 0, -1):
+        #    phase = DT*phase + self.coeffs[ii-1]
         phase += self.RPHASE + DT*60.0*self.F0
         return phase 
 
@@ -202,7 +204,6 @@ class polycos:
         """
         goodpoly = self.select_polyco(mjdi, mjdf)
         return self.polycos[goodpoly].doppler
-
 
 def create_polycos(parfn, telescope_id, center_freq, start_mjd, end_mjd, \
                     max_hour_angle=None, span=SPAN_DEFAULT, \


### PR DESCRIPTION
Here are a few assorted modifications to presto.

In particular:
1) A .tim to .dat converter
2) Using numpy's polynomial module to evaluate polycos
3) A method for writing inf files from the infodata python module. I have added an attribute and output line for pulsarcentric, de-orbited time series.

*** NOTE: I find that the C-reader of .inf files is not flexible. It assumes a specific order of lines. Hopefully the new pulsarcentric .inf line doesn't break the code! At least prepfold works properly.