### PR TITLE
barycenter: Run tempo stuff in a temporary dir rather than current dir.

### DIFF
--- a/src/barycenter.c
+++ b/src/barycenter.c
@@ -105,6 +105,17 @@ void barycenter(double *topotimes, double *barytimes,
     double fobs = 1000.0, femit, dtmp;
     char command[100], temporaryfile[100];
 
+    /* Make/chdir to a temp dir to avoid multiple prepfolds stepping on 
+     * each other.
+     */
+    char tmpdir[]  = "/tmp/prestoXXXXXX";
+    if (mkdtemp(tmpdir)==NULL) {
+        fprintf(stderr, "barycenter: error creating temp dir.\n");
+        exit(1);
+    }
+    char *origdir = getcwd(NULL,0);
+    chdir(tmpdir);
+
     /* Write the free format TEMPO file to begin barycentering */
 
     strcpy(temporaryfile, "bary.tmp");
@@ -234,4 +245,8 @@ void barycenter(double *topotimes, double *barytimes,
     remove("bary.tmp");
     remove("matrix.tmp");
     remove("bary.par");
+
+    chdir(origdir);
+    free(origdir);
+    rmdir(tmpdir);
 }


### PR DESCRIPTION
The barycenter routine calls tempo to do its calculation.  This change makes all the tempo work happen in a proper /tmp directory rather than the current dir, so that multiple prepfolds (or whatever) can be run from the same directory without stepping on each other.  I copied the code out of psrfits_utils which already uses this approach for polyco generation.