### PR TITLE
Fixes to waterfaller masking

### DIFF
--- a/bin/waterfaller.py
+++ b/bin/waterfaller.py
@@ -53,7 +53,7 @@ def get_mask(rfimask, startsamp, N):
         
 def maskfile(maskfn, data, start_bin, nbinsextra):
     rfimask = rfifind.rfifind(maskfn) 
-    mask = get_mask(rfimask, start_bin, nbinsextra)
+    mask = get_mask(rfimask, start_bin, nbinsextra)[::-1]
     masked_chans = mask.all(axis=1)
     # Mask data
     data = data.masked(mask, maskval='median-mid80')

--- a/bin/waterfaller.py
+++ b/bin/waterfaller.py
@@ -47,7 +47,9 @@ def get_mask(rfimask, startsamp, N):
     mask = np.zeros((N, rfimask.nchan), dtype='bool')
     for blocknum in np.unique(blocknums):
         blockmask = np.zeros_like(mask[blocknums==blocknum])
-        blockmask[:,rfimask.mask_zap_chans_per_int[blocknum]] = True
+        chans_to_mask = rfimask.mask_zap_chans_per_int[blocknum]
+        if chans_to_mask:
+            blockmask[:,chans_to_mask] = True
         mask[blocknums==blocknum] = blockmask
     return mask.T
         


### PR DESCRIPTION
Two fixes:

1) Important: the mask was being applied backwards in frequency, so it needed to be flipped to match the frequency order in the data

2) Allow for the case where there are no blocks to mask in the chunk of data thats being waterfalled