### PR TITLE
Adding MeerKAT site codes to PRESTO

### DIFF
--- a/src/sigproc_fb.c
+++ b/src/sigproc_fb.c
@@ -123,6 +123,10 @@ void get_telescope_name(int telescope_id, struct spectra_info *s)
         strcpy(s->telescope, "VLA");
         s->beam_FWHM = default_beam;
         break;
+    case 64:
+        strcpy(s->telescope, "MeerKAT");
+        s->beam_FWHM = default_beam;
+        break;
     default:
         strcpy(s->telescope, "Unknown");
         s->beam_FWHM = default_beam;
@@ -163,6 +167,9 @@ void get_backend_name(int machine_id, struct spectra_info *s)
         break;
     case 12:
         strcpy(string, "PDEV");
+        break;
+    case 64:
+        strcpy(string, "KAT");
         break;
     default:
         strcpy(s->backend, "Unknown");

--- a/src/sigproc_fb.c
+++ b/src/sigproc_fb.c
@@ -127,6 +127,10 @@ void get_telescope_name(int telescope_id, struct spectra_info *s)
         strcpy(s->telescope, "MeerKAT");
         s->beam_FWHM = default_beam;
         break;
+    case 65:
+        strcpy(s->telescope, "KAT-7");
+        s->beam_FWHM = default_beam;
+        break;
     default:
         strcpy(s->telescope, "Unknown");
         s->beam_FWHM = default_beam;
@@ -170,6 +174,9 @@ void get_backend_name(int machine_id, struct spectra_info *s)
         break;
     case 64:
         strcpy(string, "KAT");
+        break;
+    case 65:
+        strcpy(string, "KAT-DC2");
         break;
     default:
         strcpy(s->backend, "Unknown");


### PR DESCRIPTION
Dear Scott,

This adds MeerKAT site code and MeerKAT (generic) backend code to the PRESTO. Both site and backend has been added to SIGPROC so there are no inconsistencies.

BTW. I kept the beam size default as currently it is ~1 degree at L-band with 16 core dishes.

Best regards,
Maciej