### PR TITLE
Update rfifind.py

### DIFF
--- a/lib/python/rfifind.py
+++ b/lib/python/rfifind.py
@@ -83,7 +83,9 @@ class rfifind:
         nzap_per_int = np.fromfile(x, dtype=np.int32, count=nint)
         self.mask_zap_chans_per_int = []
         for nzap in nzap_per_int:
-            if nzap:
+            if nzap == nchan:
+                tozap = np.arange(0,nchan)
+            elif nzap > 0:
                 tozap = np.fromfile(x, dtype=np.int32, count=nzap)
             else:
                 tozap = np.asarray([])


### PR DESCRIPTION
In read_mask(), there is a problem if all the channels in a sub-intergartion are zapped, when zap == nchan. It should not read anything from the mask but insert an array filled with all the channels instead. If I understand it correctly.