### PR TITLE
waterfaller.py on sigproc files

### DIFF
--- a/bin/injectpsr.py
+++ b/bin/injectpsr.py
@@ -921,7 +921,7 @@ def inject(infile, outfn, prof, period, dm, nbitsout=None,
         
         # Prepare for next iteration
         lobin = hibin 
-        spectra = fil.get_spectra(lobin, lobin+block_size)
+        spectra = fil.get_spectra(lobin, block_size)
         numread = spectra.shape[0]
 
     sys.stdout.write("Done   \n")

--- a/bin/waterfaller.py
+++ b/bin/waterfaller.py
@@ -23,7 +23,7 @@ import psr_utils
 import rfifind
 
 import psrfits
-#import filterbank # need to implement in PRESTO!
+import filterbank
 import spectra
 
 SWEEP_STYLES = ['r-', 'b-', 'g-', 'm-', 'c-']
@@ -114,9 +114,10 @@ def waterfall(rawdatafile, start, duration, dm=None, nbins=None, nsub=None,\
         ref_freq = rawdatafile.freqs.max()
 
     if nsub and dm:
+        df = rawdatafile.freqs[1] - rawdatafile.freqs[0]
         nchan_per_sub = rawdatafile.nchan/nsub
         top_ctrfreq = rawdatafile.freqs.max() - \
-                      0.5*nchan_per_sub*rawdatafile.specinfo.df # center of top subband
+                      0.5*nchan_per_sub*df # center of top subband
         start += 4.15e3 * np.abs(1./ref_freq**2 - 1./top_ctrfreq**2) * dm
 
     start_bin = np.round(start/rawdatafile.tsamp).astype('int')
@@ -131,8 +132,8 @@ def waterfall(rawdatafile, start, duration, dm=None, nbins=None, nsub=None,\
         nbinsextra = nbins    
 
     # If at end of observation
-    if (start_bin + nbinsextra) > rawdatafile.specinfo.N-1:
-        nbinsextra = rawdatafile.specinfo.N-1-start_bin
+    if (start_bin + nbinsextra) > rawdatafile.nspec-1:
+        nbinsextra = rawdatafile.nspec-1-start_bin
 
     data = rawdatafile.get_spectra(start_bin, nbinsextra)
 
@@ -283,8 +284,8 @@ def main():
     if fn.endswith(".fil"):
         # Filterbank file
         filetype = "filterbank"
-        rawdatafile = filterbank.filterbank(fn)
-    if fn.endswith(".fits"):
+        rawdatafile = filterbank.FilterbankFile(fn)
+    elif fn.endswith(".fits"):
         # PSRFITS file
         filetype = "psrfits"
         rawdatafile = psrfits.PsrfitsFile(fn)

--- a/lib/python/filterbank.py
+++ b/lib/python/filterbank.py
@@ -215,7 +215,6 @@ class FilterbankFile(object):
         spectra_dat = np.fromfile(self.filfile, dtype=self.dtype, 
                               count=num_to_read)
         spectra_dat.shape = nspec, self.nchans 
-        print spectra_dat.shape
         spec = spectra.Spectra(self.freqs, self.tsamp, spectra_dat.T,
                 starttime=start*self.tsamp, dm=0.0)
         return spec

--- a/lib/python/filterbank.py
+++ b/lib/python/filterbank.py
@@ -11,6 +11,7 @@ import os
 import os.path
 import numpy as np
 import sigproc
+import spectra
 
 
 DEBUG = False
@@ -184,6 +185,16 @@ class FilterbankFile(object):
         else:
             raise ValueError("Unrecognized mode (%s)!" % mode)
 
+    @property
+    def freqs(self):
+        # Alias for frequencies
+        return self.frequencies
+
+    @property
+    def nchan(self):
+        # more aliases..
+        return self.nchans
+
     def close(self):
         if self.filfile is not None:
             self.filfile.close()
@@ -191,20 +202,23 @@ class FilterbankFile(object):
     def get_timeslice(self, start, stop):
         startspec = int(np.round(start/self.tsamp))
         stopspec = int(np.round(stop/self.tsamp))
-        return self.get_spectra(startbins, stopbins)
+        return self.get_spectra(startspec, stopspec-startspec)
 
-    def get_spectra(self, start, stop):
-        stop = min(stop, self.nspec)
+    def get_spectra(self, start, nspec):
+        stop = min(start+nspec, self.nspec)
         pos = self.header_size+start*self.bytes_per_spectrum
         # Compute number of elements to read
         nspec = int(stop) - int(start)
         num_to_read = nspec*self.nchans
         num_to_read = max(0, num_to_read)
         self.filfile.seek(pos, os.SEEK_SET)
-        spectra = np.fromfile(self.filfile, dtype=self.dtype, 
+        spectra_dat = np.fromfile(self.filfile, dtype=self.dtype, 
                               count=num_to_read)
-        spectra.shape = nspec, self.nchans 
-        return spectra
+        spectra_dat.shape = nspec, self.nchans 
+        print spectra_dat.shape
+        spec = spectra.Spectra(self.freqs, self.tsamp, spectra_dat.T,
+                starttime=start*self.tsamp, dm=0.0)
+        return spec
 
     def append_spectra(self, spectra):
         """Append spectra to the file if is not read-only.

--- a/lib/python/psrfits.py
+++ b/lib/python/psrfits.py
@@ -81,6 +81,7 @@ class PsrfitsFile(object):
         self.freqs = self.fits['SUBINT'].data[0]['DAT_FREQ'] 
         self.frequencies = self.freqs # Alias
         self.tsamp = self.specinfo.dt
+        self.nspec = self.specinfo.N
 
     def read_subint(self, isub, apply_weights=True, apply_scales=True, \
                     apply_offsets=True):


### PR DESCRIPTION
I made a few pretty trivial changes in order to make waterfaller.py work on sigproc-format ("filterbank") files.  The only thing that might be notable is that the FilterbankFile.get_spectra() method behaves a bit differently; it now takes start and nspectra (rather than start/stop) arguments, and now returns a Spectra object (rather than a numpy array).  The new version is consistent with PsrfitsFile.get_spectra().