### PR TITLE
Explicitly cast 'bins' as integer in 'rotate' function so that it can

### DIFF
--- a/lib/python/psr_utils.py
+++ b/lib/python/psr_utils.py
@@ -996,7 +996,7 @@ def rotate(arr, bins):
     rotate(arr, bins):
         Return an array rotated by 'bins' places to the left
     """
-    bins = int(bins % len(arr))
+    bins = int(bins) % len(arr)
     if bins==0:
         return arr
     else:

--- a/lib/python/psr_utils.py
+++ b/lib/python/psr_utils.py
@@ -996,7 +996,7 @@ def rotate(arr, bins):
     rotate(arr, bins):
         Return an array rotated by 'bins' places to the left
     """
-    bins = bins % len(arr)
+    bins = int(bins % len(arr))
     if bins==0:
         return arr
     else:


### PR DESCRIPTION
be used as a slice index in arrays