### PR TITLE
Changed headers so that stdio.h is included before stdlib.h

### DIFF
--- a/include/makedata.h
+++ b/include/makedata.h
@@ -1,8 +1,8 @@
 /*    Pulsar Data Generation Program       */
 /*          by Scott Ransom                */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include "chkio.h"

--- a/include/makeinf.h
+++ b/include/makeinf.h
@@ -1,8 +1,8 @@
 /*    Pulsar Data Set Info File Creator     */
 /*          by Scott Ransom                 */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include "chkio.h"

--- a/include/orbint.h
+++ b/include/orbint.h
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include "vectors.h"
 

--- a/include/ransomfft.h
+++ b/include/ransomfft.h
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 #include <stdio.h>

--- a/include/vectors.h
+++ b/include/vectors.h
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "fftw3.h"
 #include "rawtype.h"
 

--- a/src/cal2mjd.c
+++ b/src/cal2mjd.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 
 double slaCldj(int iy, int im, int id, int *j);

--- a/src/djcl.c
+++ b/src/djcl.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 #include "slamac.h"

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -66,11 +66,11 @@
  *		Return 1 if file is a FITS file, else 0
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #ifndef VMS
 #include <unistd.h>
 #endif
-#include <stdio.h>
 #include <fcntl.h>
 #include <sys/file.h>
 #include <errno.h>

--- a/src/fresnl.c
+++ b/src/fresnl.c
@@ -59,6 +59,7 @@
    Copyright 1984, 1987, 1989 by Stephen L. Moshier
  */
 
+#include <stdio.h>
 #include<stdlib.h>
 #include<math.h>
 

--- a/src/imio.c
+++ b/src/imio.c
@@ -58,8 +58,8 @@
  *		Return 1 if PC/DEC byte order, else 0
  */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "imio.h"
 
 static int scale = 1;           /* If 0, skip scaling step */

--- a/src/makewisdom.c
+++ b/src/makewisdom.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include "meminfo.h"
 #include "fftw3.h"

--- a/src/mjd2cal.c
+++ b/src/mjd2cal.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include "slamac.h"

--- a/src/patchdata.c
+++ b/src/patchdata.c
@@ -3,8 +3,8 @@
 /*           by Scott M. Ransom               */
 /*               1 Mar 1999                   */
 /*                                            */
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define WORKLEN 16384

--- a/src/psrfits_dumparrays.c
+++ b/src/psrfits_dumparrays.c
@@ -1,5 +1,5 @@
-#include "stdlib.h"
 #include "stdio.h"
+#include "stdlib.h"
 #include "string.h"
 #include "fitsio.h"
 

--- a/src/shiftdata.c
+++ b/src/shiftdata.c
@@ -3,8 +3,8 @@
 /*        by Scott M. Ransom          */
 /*            1 Mar 1999              */
 /*                                    */
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/taperaw.c
+++ b/src/taperaw.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define BLOCKLEN 49792
 

--- a/src/toas2dat.c
+++ b/src/toas2dat.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
For some reason MacOS 10.14 has problems if stdlib.h is included before stdio.h.
This PR fixes that.
