### PR TITLE
get_TOAs.py bugfixes

### DIFF
--- a/bin/get_TOAs.py
+++ b/bin/get_TOAs.py
@@ -335,17 +335,17 @@ if __name__ == '__main__':
                     continue
                 # Interpolate the data
                 if (len(template) > fold_pfd.proflen):
-                    prof = psr_utils.linear_interpolate(prof, len(template)/fold_pfd.proflen)
+                    prof = psr_utils.linear_interpolate(prof, len(template)//fold_pfd.proflen)
                     if not ii and not jj:
                         sys.stderr.write("Note: Interpolating the data for '%s'\n"%fold_pfd.filenm)
                 # Interpolate the template
                 elif (1):
-                    template = psr_utils.linear_interpolate(template, fold_pfd.proflen/len(template))
+                    template = psr_utils.linear_interpolate(template, fold_pfd.proflen//len(template))
                     if not ii and not jj:
                         sys.stderr.write("Note: Interpolating the template for '%s'\n"%fold_pfd.filenm)
                 # Downsample the data (Probably not a good idea)
                 else:
-                    prof = psr_utils.downsample(prof, fold_pfd.proflen/len(template))
+                    prof = psr_utils.downsample(prof, fold_pfd.proflen//len(template))
                     if not ii and not jj:
                         sys.stderr.write("Note:  Downsampling the data for '%s'\n"%fold_pfd.filenm)
 

--- a/python/presto/prepfold.py
+++ b/python/presto/prepfold.py
@@ -33,7 +33,7 @@ class pfd(object):
          self.ndmfact, self.npfact) = struct.unpack(swapchar+"i"*7, infile.read(7*4))
 
         self.filenm = infile.read(struct.unpack(swapchar+"i", infile.read(4))[0])
-        self.candnm = infile.read(struct.unpack(swapchar+"i", infile.read(4))[0])
+        self.candnm = infile.read(struct.unpack(swapchar+"i", infile.read(4))[0]).decode("utf-8")
         self.telescope = infile.read(struct.unpack(swapchar+"i", infile.read(4))[0]).decode("utf-8")
         self.pgdev = infile.read(struct.unpack(swapchar+"i", infile.read(4))[0])
         test = infile.read(16)
@@ -175,11 +175,12 @@ class pfd(object):
         infile.close()
         self.barysubfreqs = None
         if self.avgvoverc==0:
-            if self.candnm.startswith(b"PSR_"):
+            if self.candnm.startswith("PSR_"):
                 # If this doesn't work, we should try to use the barycentering calcs
                 # in the presto module.
                 try:
-                    self.polycos = polycos.polycos(self.candnm[4:],
+                    psrname = self.candnm[4:]
+                    self.polycos = polycos.polycos(psrname,
                                                    filenm=self.pfd_filename+".polycos")
                     midMJD = self.tepoch + 0.5*self.T/86400.0
                     self.avgvoverc = self.polycos.get_voverc(int(midMJD), midMJD-int(midMJD))


### PR DESCRIPTION
I tried using get_TOAs.py to make TOAs and got a couple of failures under python3. 

One was that the candnm was a bytestring and thus was not working, so I added a .decode("utf-8") to fix that.  I'm not sure how compatible this is with Python2, but it was used for another entry that was being read as well so I figured it was OK.  Probably some of the other strings that are read as bytes should also be converted to proper  strings that way.

The other was that "/" was being used for division and causing it to try to index an array by a float. I converted to integer division. This should be fine as long as the code ensures that it evenly divides. I have not checked to see if this is guaranteed, but I think this is how it would have worked in Python2 so it should be good.