### PR TITLE
minor fixes to guppidrift2fil.py, sigproc.py, downsample_filterbank.py

### DIFF
--- a/bin/downsample_filterbank.py
+++ b/bin/downsample_filterbank.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     basefilenm = sys.argv[2][:sys.argv[2].find(".fil")]
     
     filhdr = {}
-    newhdr = ""
+    newhdr = "".encode('utf-8')
     infile = open(sys.argv[2], 'rb')
 
     # Determine the full size of the file

--- a/bin/guppidrift2fil.py
+++ b/bin/guppidrift2fil.py
@@ -13,7 +13,7 @@ import time
 from math import *
 # 2/13/2014 //NEG-D///
 import pyslalib.slalib as sla
-import presto as presto
+from presto import presto
 fil_header_keys = [
     "telescope_id",
     "machine_id",
@@ -166,7 +166,7 @@ def translate_header(fits_file,skip,output_subints):
     fil_header["src_raj"] = float(hours*10000.0 + hmin*100.0 +  hsec)
     fil_header["src_dej"] = float(deg*10000.0 + dmin*100.0 + dsec)
 
-    fn = fits_file._HDUList__file.name
+    fn = fits_file.filename()
     fil_header["rawdatafile"] = os.path.basename(fn) 
     fil_header["source_name"] = fits_hdr['SRC_NAME']
     fil_header["barycentric"] = 0 # always not barycentered?
@@ -261,19 +261,19 @@ def main(fits_fn, outfn, nbits, \
     sys.stdout.flush()
     oldpcnt = ""
     for i in range(skip+1,output_subints+skip+1):
-        index = (i-1)/320
+        index = (i-1)//320
         subint_in_file = i-1-(index * 320)
         subint = read_subint(fits[index],subint_in_file,nchan,nsamps, \
                     apply_weights, apply_scales, apply_offsets, \
                     input_nbits=input_nbits)
         if flip_band:
             subint = np.fliplr(subint)
-    subint /= scale_fac
-    outfil.append_spectra(subint)
-    pcnt = "%d" % (i*100.0/output_subints)
-    if pcnt != oldpcnt:
-        sys.stdout.write("% 4s%% complete\r" % pcnt)
-        sys.stdout.flush()
+        subint /= scale_fac
+        outfil.append_spectra(subint)
+        pcnt = "%d" % (i*100.0/output_subints)
+        if pcnt != oldpcnt:
+           sys.stdout.write("% 4s%% complete\r" % pcnt)
+           sys.stdout.flush()
 
     print("Done               ")
     outfil.close()

--- a/python/presto/sigproc.py
+++ b/python/presto/sigproc.py
@@ -167,7 +167,7 @@ def read_header(infile):
     """
     hdrdict = {}
     if type(infile) == type("abc"):
-        infile = open(infile)
+        infile = open(infile,'rb')
     param = ""
     while (param != "HEADER_END"):
         param, val = read_hdr_val(infile, stdout=False)


### PR DESCRIPTION
Hours2hms etc functions are from the presto package, which is under presto (i.e presto.presto), so we need to import presto from presto.

Fixed floor division for index.

Changed fits_file._HDUList__file.name to fits_file.filename().  filename is a cleaner way (and designed purpose) of getting the filename. Also, less buggy (don't know if HDUList is supported still so better to transition i.e https://github.com/astropy/astropy/issues/6937).

Fixed indentation for progress bar and subint appending (as it was originally laying outside the loop's block).

this fixes things for me, i.e filterbank file does write, yay!. But Guppi_drift_prep is putting out a "utf-8 codec can't decode byte ... : invalid start byte". So I'll look into that (but I'll safe it for a separate pull request -- rather want to keep each pull request as specific as possible, and guppidrift2fil is fixed)