### PR TITLE
added import of subprocess

### DIFF
--- a/bin/pygaussfit.py
+++ b/bin/pygaussfit.py
@@ -10,7 +10,7 @@ from presto.bestprof import bestprof
 import matplotlib.pyplot as plt
 import numpy as Num
 from presto import mpfit
-
+import subprocess
 
 class GaussianSelector(object):
     def __init__(self, ax, profile, errs, profnm, minspanx=None,


### PR DESCRIPTION
When running `pygaussfit` with a `pfd` input, it tries to run `show_pfd` using `subprocess` but there was no import statement for that module.