### PR TITLE
simple_zapbirds: find the last "_DM" in filename rather than the first

### DIFF
--- a/bin/simple_zapbirds.py
+++ b/bin/simple_zapbirds.py
@@ -67,7 +67,7 @@ def group_infiles(infilenms):
     DMs = []
     for name in names:
         try:
-            ind = name.index("_DM")
+            ind = name.rfind("_DM")
             if name[:ind] not in basenames:
                 basenames.append(name[:ind])
             try:


### PR DESCRIPTION
Very minor change
The script now looks for the last occurrence of "_DM" in the filename rather than the first.

Comes up if the original filterbank was coherently dedispersed and had a name like `J1111+11_DM22_59877_pow.fil` so the dedispersed fft's have names like `J1111+11_DM22_59877_pow_DM76.42.fft`
It will now identify the DM as 76.42 not 22