### PR TITLE
Support sigproc keyword refdm.

### DIFF
--- a/include/sigproc_fb.h
+++ b/include/sigproc_fb.h
@@ -13,6 +13,7 @@ typedef struct SIGPROCFB {
   double za_start;       /* Starting zenith angle in deg */
   double fch1;           /* Highest channel frequency (MHz) */
   double foff;           /* Channel stepsize (MHz) */
+  double refdm;          /* Reference dispersion measure (pc/cm^3) */
   int machine_id;        /* Instrument ID (see backend_name() */
   int telescope_id;      /* Telescope ID (see telescope_name() */
   int nchans;            /* Number of finterbank channels */

--- a/src/sigproc_fb.c
+++ b/src/sigproc_fb.c
@@ -290,6 +290,9 @@ int read_filterbank_header(sigprocfb * fb, FILE * inputfile)
         } else if (strings_equal(string, "foff")) {
             chkfread(&(fb->foff), sizeof(double), 1, inputfile);
             totalbytes += sizeof(double);
+        } else if (strings_equal(string, "refdm")) {
+            chkfread(&(fb->refdm), sizeof(double), 1, inputfile);
+            totalbytes += sizeof(double);
         } else if (strings_equal(string, "nchans")) {
             chkfread(&(fb->nchans), sizeof(int), 1, inputfile);
             totalbytes += sizeof(int);


### PR DESCRIPTION
Adds the ability to read the `refdm` keyword in SIGPROC filterbank headers. 

Currently, it results in (with `readfile`)
`ERROR: read_filterbank_header - unknown parameter: refdm`