### PR TITLE
Fixing a link in the FAQ.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -623,7 +623,7 @@ list to update for a long time...
 
 For reference, the details as to what is going on in these codes is described in
 [Ransom, Cordes, & Eikenberry,
-2003](https://ui.adsabs.harvard.edu/abs/2003ApJ...589..911R/abstract}).
+2003](https://ui.adsabs.harvard.edu/abs/2003ApJ...589..911R/abstract).
 
 -----------------
 


### PR DESCRIPTION
I was just reading through and saw that one of the links had a stray curly bracket, so thought I would make a mini-PR to fix it.