### PR TITLE
Set `summed_polns = 0` when `fb.sumifs == false` in sigproc_fb.c

### DIFF
--- a/src/sigproc_fb.c
+++ b/src/sigproc_fb.c
@@ -397,6 +397,7 @@ void read_filterbank_files(struct spectra_info *s)
         s->summed_polns = 1;
         s->num_polns = 1;
     } else {
+        s->summed_polns = 0;
         s->num_polns = fb.nifs;
         strncpy(s->poln_order, fb.ifstream, 8);
     }


### PR DESCRIPTION
I'm still learning pulsar things, so please correct me if I'm wrong.

The default value of `summed_polns` is 1 in [backend_common.c](https://github.com/scottransom/presto/blob/93624f74c8f95fd7cde13eeaba97fabebd0ae604/src/backend_common.c#L182), so I think it need to be explicitly set to 0 here, so that `readfile` gives correct output ( affects [this](https://github.com/scottransom/presto/blob/93624f74c8f95fd7cde13eeaba97fabebd0ae604/src/backend_common.c#L262) )

Also, the `fb.ifstream` is accessed in the next lines but seems never read from .fil files, which will affect `s->poln_order` and finally cause `readfile`'s `Polarization order = <some random stack memory data here>`. But I cannot find some document about this header, so didn't change this.