### PR TITLE
Improve rednoise behaviour when writing output files

### DIFF
--- a/src/rednoise.c
+++ b/src/rednoise.c
@@ -3,7 +3,6 @@
 #include "rednoise_cmd.h"
 #ifdef USEDMALLOC
 #include "dmalloc.h"
-#include "misc_utils.h"
 #endif
 
 #include <sys/types.h>
@@ -43,7 +42,7 @@ int main(int argc, char *argv[])
     {
         int hassuffix = 0;
         char *suffix;
-        
+
         hassuffix = split_root_suffix(cmd->argv[0], &rootfilenm, &suffix);
         if (hassuffix) {
             if (strcmp(suffix, "fft") != 0) {
@@ -71,7 +70,7 @@ int main(int argc, char *argv[])
         fcomplex *newbuf, *oldbuf, *inbuf1, *inbuf2, *outbuf, *tempzz;
 
         struct stat info;
-        
+
         /* Read the info file, and write a copy */
         {
             char *newinf;
@@ -85,54 +84,56 @@ int main(int argc, char *argv[])
             T = numsamp * idata.dt;
 
             split_path_file(idata.name, &infdir, &filenm);
-            
+
             newinf = (char *) calloc(strlen(idata.name) + 5, sizeof(char));
 
             /* Uncomment for debugging 
-            printf("idata.name: %s\n", idata.name);
-            printf("rootfilenm: %s\n", rootfilenm);
-            printf("infdir: %s\n", infdir);
-            printf("filenm: %s\n", filenm)
-            */
+               printf("idata.name: %s\n", idata.name);
+               printf("rootfilenm: %s\n", rootfilenm);
+               printf("infdir: %s\n", infdir);
+               printf("filenm: %s\n", filenm)
+             */
 
-            if( stat( infdir, &info ) != 0 ) {
-                    printf("WARNING: Original directory '%s' does not exists!\n", infdir );
-                    printf("         Writing output files in the current working directory.\n");
-                    sprintf(newinf, "%s_red", rootfilenm);
-                    sprintf(outname, "%s_red.fft", rootfilenm);
-                    sprintf(idata.name, "%s", newinf);
-                    
-                    fftfullpath = (char *) calloc(strlen(outname), sizeof(char));
-                    inffullpath = (char *) calloc(strlen(outname), sizeof(char));                    
-                    sprintf(fftfullpath, "./%s_red.fft", rootfilenm);
-                    sprintf(inffullpath, "./%s_red.inf", rootfilenm);
-                    
-                    //Uncomment for debugging
-                    //printf("newinf: %s\n", newinf);
-                    //printf("outname case 1: %s\n", outname);
-                    
-            
+            if (stat(infdir, &info) != 0) {
+                printf("WARNING: Original directory '%s' does not exists!\n",
+                       infdir);
+                printf
+                    ("         Writing output files in the current working directory.\n");
+                sprintf(newinf, "%s_red", rootfilenm);
+                sprintf(outname, "%s_red.fft", rootfilenm);
+                sprintf(idata.name, "%s", newinf);
+
+                fftfullpath = (char *) calloc(strlen(outname), sizeof(char));
+                inffullpath = (char *) calloc(strlen(outname), sizeof(char));
+                sprintf(fftfullpath, "./%s_red.fft", rootfilenm);
+                sprintf(inffullpath, "./%s_red.inf", rootfilenm);
+
+                //Uncomment for debugging
+                //printf("newinf: %s\n", newinf);
+                //printf("outname case 1: %s\n", outname);
+
+
             } else {
-                    //printf( "Directory %s exists! All good.\n", infdir );
-                    sprintf(newinf, "%s_red", idata.name);
-                    sprintf(idata.name, "%s", newinf);
-                    sprintf(outname, "%s.fft", newinf);
-                    
-                    fftfullpath = (char *) calloc(strlen(outname), sizeof(char));
-                    inffullpath = (char *) calloc(strlen(outname), sizeof(char));
-                    sprintf(fftfullpath, "%s.fft", idata.name);
-                    sprintf(inffullpath, "%s.inf", idata.name);
+                //printf( "Directory %s exists! All good.\n", infdir );
+                sprintf(newinf, "%s_red", idata.name);
+                sprintf(idata.name, "%s", newinf);
+                sprintf(outname, "%s.fft", newinf);
 
-                    //Uncomment for debugging
-                    //printf("newinf: %s\n", newinf);                    
-                    //printf("outname case 2: %s\n", outname);
+                fftfullpath = (char *) calloc(strlen(outname), sizeof(char));
+                inffullpath = (char *) calloc(strlen(outname), sizeof(char));
+                sprintf(fftfullpath, "%s.fft", idata.name);
+                sprintf(inffullpath, "%s.inf", idata.name);
+
+                //Uncomment for debugging
+                //printf("newinf: %s\n", newinf);                    
+                //printf("outname case 2: %s\n", outname);
             }
 
             /* Uncomment for debugging
-            sprintf(newinf, "%s_red", idata.name);
-            sprintf(idata.name, "%s", newinf);
-            printf("newinf: %s\n", newinf);
-            */
+               sprintf(newinf, "%s_red", idata.name);
+               sprintf(idata.name, "%s", newinf);
+               printf("newinf: %s\n", newinf);
+             */
             writeinf(&idata);
             free(newinf);
         }
@@ -263,5 +264,7 @@ int main(int argc, char *argv[])
     fclose(outfile);
     free(rootfilenm);
     free(outname);
+    free(fftfullpath);
+    free(inffullpath);
     exit(0);
 }


### PR DESCRIPTION
rednoise now always writes the *_red.fft and *_red.inf files in the same directory (previously it would write the *_red.fft file in the current working directory, and the *_red.inf file in the directory specified in the "Data file name without suffix" entry of the original *.inf file)

Also, if the directory specified in the original *.inf file does not exist, rednoise now writes the output files in the current working directory (previously it would crash).

Finally, it now prints the paths of the output files, similarly to other PRESTO routines.