### PR TITLE
Fix EPS2DOT handling in readpar

### DIFF
--- a/src/readpar.c
+++ b/src/readpar.c
@@ -247,7 +247,7 @@ int get_psr_from_parfile(char *parfilenm, double epoch, psrparams * psr)
         psr->orb.x += xd * orbdifft;
         psr->orb.e += ed * orbdifft;
         eps1 += eps1d * orbdifft;
-        eps2 += eps1d * orbdifft;
+        eps2 += eps2d * orbdifft;
         if (eps1 != 0.0 || eps2 != 0.0) {
             /* Convert Laplace-Lagrange params to e and w */
             /* Warning!  This is presently untested!      */


### PR DESCRIPTION
 In `src/readpar.c`, EPS2 is updated using eps1d instead of eps2d, so EPS2DOT is effectively ignored.

 Code excerpt (at src/readpar.c:249):

```
 eps1 += eps1d * orbdifft;
 eps2 += eps1d * orbdifft;  // should use eps2d
```