### PR TITLE
fixed compiler warnings

### DIFF
--- a/src/accel_utils.c
+++ b/src/accel_utils.c
@@ -115,7 +115,7 @@ static void compare_rzw_cands(fourierprops *list, int nlist, char *notes)
                 fabs(list[ii].z - list[jj].z) > 1.0 && list[ii].pow > list[jj].pow) {
                 if (strncmp(notes + jj * 20, "                      ", 20) == 0) {
                     sprintf(tmp, "SL? of Cand %d", ii + 1);
-                    strncpy(notes + jj * 20, tmp, 20);
+                    memcpy(notes + jj * 20, tmp, 20);
                 }
                 continue;
             }
@@ -124,7 +124,7 @@ static void compare_rzw_cands(fourierprops *list, int nlist, char *notes)
                     (fabs(list[ii].z - list[jj].z / kk) < list[jj].zerr * 2)) {
                     if (strncmp(notes + jj * 20, "                      ", 20) == 0) {
                         sprintf(tmp, "H %d of Cand %d", kk, ii + 1);
-                        strncpy(notes + jj * 20, tmp, 20);
+                        memcpy(notes + jj * 20, tmp, 20);
                         break;
                     }
                 }
@@ -638,9 +638,9 @@ static void center_string(char *outstring, char *instring, int width)
     memset(outstring, ' ', width);
     outstring[width] = '\0';
     if (len >= width) {
-        strncpy(outstring, instring, width);
+        memcpy(outstring, instring, width);
     } else {
-        strncpy(outstring + (width - len) / 2, instring, len);
+        memcpy(outstring + (width - len) / 2, instring, len);
     }
 }
 
@@ -1137,9 +1137,6 @@ ffdotpows *subharm_fderivs_vol(int numharm, int harmnum,
         vect_free(tmpout);
     }
 
-    fcomplex *tmpdat = gen_cvect(fftlen);
-    fcomplex *tmpout = gen_cvect(fftlen);
-
     // Perform the correlations in a thread-safe manner
 #ifdef _OPENMP
 #pragma omp parallel default(none) shared(pdata,shi,fftlen,binoffset,ffdot,invplan)
@@ -1338,7 +1335,7 @@ void inmem_add_ffdotpows(ffdotpows *fundamental, accelobs *obs,
         const long long rlen = (obs->highestbin + obs->corr_uselen) * ACCEL_RDR;
         float *powptr = fundamental->powers[0][0];
         float *fdp = obs->ffdotplane;
-        int ii, jj, zz, zind, subz;
+        int jj, zz, zind, subz;
         float *inpows, *outpows;
         long long offset;
 #ifdef _OPENMP

--- a/src/accelsearch.c
+++ b/src/accelsearch.c
@@ -42,9 +42,6 @@ static void print_percent_complete(int current, int number, char *what, int rese
 
 int main(int argc, char *argv[])
 {
-	struct timespec start, end;
-	clock_gettime(CLOCK_MONOTONIC, &start);
-
     int ii, rstep;
     double ttim, utim, stim, tott;
     struct tms runtimes;
@@ -312,11 +309,6 @@ int main(int argc, char *argv[])
     free_accelobs(&obs);
     g_slist_foreach(cands, free_accelcand, NULL);
     g_slist_free(cands);
-	
-	clock_gettime(CLOCK_MONOTONIC, &end);
-	long long tot = 0;
-	tot = (end.tv_sec - start.tv_sec) * 1000000000LL - (end.tv_nsec - start.tv_nsec);
-	printf("Total Time: %lld\n", tot);
     
     return (0);
 }

--- a/src/accelsearch.c
+++ b/src/accelsearch.c
@@ -42,6 +42,9 @@ static void print_percent_complete(int current, int number, char *what, int rese
 
 int main(int argc, char *argv[])
 {
+	struct timespec start, end;
+	clock_gettime(CLOCK_MONOTONIC, &start);
+
     int ii, rstep;
     double ttim, utim, stim, tott;
     struct tms runtimes;
@@ -309,5 +312,11 @@ int main(int argc, char *argv[])
     free_accelobs(&obs);
     g_slist_foreach(cands, free_accelcand, NULL);
     g_slist_free(cands);
+	
+	clock_gettime(CLOCK_MONOTONIC, &end);
+	long long tot = 0;
+	tot = (end.tv_sec - start.tv_sec) * 1000000000LL - (end.tv_nsec - start.tv_nsec);
+	printf("Total Time: %lld\n", tot);
+    
     return (0);
 }

--- a/src/accelsearch_cmd.c
+++ b/src/accelsearch_cmd.c
@@ -789,9 +789,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/bincand.c
+++ b/src/bincand.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     unsigned long filelen;
     double numsearched = 0.0, numtosearch = 0.0, trial_time, avg_time;
     fcomplex *data = NULL, *corrdata = NULL;
-    orbitparams trialorb, orb, bestorb;
+    orbitparams trialorb, orb, bestorb = {0};
     infodata idata;
     makedata mdata;
     psrparams psr;
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
         phiorb = TWOPI * trialorb.x / ppsr;
         rorb = T / trialorb.p;
         ro = T / ppsr;
-        if (strcmp("PSR B        ", psr.bname) == 0)
+        if (strncmp("PSR B        ", psr.bname, sizeof(psr.bname) - 1) == 0)
             printf("Using parameters from pulsar %s\n\n", psr.jname);
         else
             printf("Using parameters from pulsar %s\n\n", psr.bname);

--- a/src/bincand_cmd.c
+++ b/src/bincand_cmd.c
@@ -783,9 +783,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/cand_output.c
+++ b/src/cand_output.c
@@ -13,7 +13,7 @@ void file_reg_candidates(fourierprops cand[], char *notes, int numcands,
     double T, pownph, pownpherr;
     int i, j, k = 0;
     int nlines = 77, pages, extralines, nwrit, linestoprint;
-    char output[40], infonm[100], command[200], tmp[] = "";
+    char output[40], infonm[100], command[300], tmp[] = "";
     rzwerrs rzws;
 
     sprintf(infonm, "%s.inf", name);
@@ -130,7 +130,7 @@ void file_bin_candidates(binaryprops cand[], char *notes, int numcands, char nam
     FILE *fname;
     int i, j, k = 0, wide;
     int nlines = 77, pages, extralines, nwrit, linestoprint;
-    char output[40], filenm[100], infonm[100], command[200], tmp[] = "";
+    char output[40], filenm[100], infonm[100], command[300], tmp[] = "";
 
     sprintf(filenm, "%s_bin", name);
     sprintf(infonm, "%s.inf", name);

--- a/src/database.c
+++ b/src/database.c
@@ -4,7 +4,7 @@
 static psrparams pulsardata[NP];
 static int np = 0, have_database = 0;
 
-static char num[41][5] = { "0th", "1st", "2nd", "3rd", "4th", "5th", "6th",
+static const char *const num[] = { "0th", "1st", "2nd", "3rd", "4th", "5th", "6th",
     "7th", "8th", "9th", "10th", "11th", "12th",
     "13th", "14th", "15th", "16th", "17th", "18th",
     "19th", "20th", "21st", "22nd", "23rd", "24th",
@@ -384,8 +384,8 @@ int comp_psr_to_cand(fourierprops * cand, infodata * idata, char *output, int fu
         sprintf(output,
                 "I don't recognize this candidate in the pulsar database.\n");
     } else {
-        strncpy(output, "                       ", 20);
-        output[20-1] = '\0';
+        memset(output, ' ', 19);
+        output[19] = '\0';
     }
     return 0;
 }
@@ -512,8 +512,8 @@ int comp_bin_to_cand(binaryprops * cand, infodata * idata, char *output, int ful
         sprintf(output,
                 "I don't recognize this candidate in the pulsar database.\n");
     } else {
-        strncpy(output, "                       ", 20);
-        output[20-1] = '\0';
+        memset(output, ' ', 19);
+        output[19] = '\0';
     }
     return 0;
 }

--- a/src/dftfold_cmd.c
+++ b/src/dftfold_cmd.c
@@ -749,9 +749,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/dispersion.c
+++ b/src/dispersion.c
@@ -183,19 +183,19 @@ void dedisp_subbands(float *data, float *lastdata,
         result[ii] = 0.0;
 
     /* De-disperse into the subbands */
-// #ifdef _OPENMP
-// #pragma omp parallel for schedule(static,chan_per_subband)\
-//    default(none) private(ii,jj) shared(result,data,lastdata,delays,numchan,numpts)
-// #endif
+/* #ifdef _OPENMP
+   #pragma omp parallel for schedule(static,chan_per_subband) \
+   default(none) private(ii,jj) shared(result,data,lastdata,delays,numchan,numpts)
+   #endif */
     for (ii = 0; ii < numchan; ii++) {
         const int subnum = ii / chan_per_subband;
         const int dind = delays[ii];
         float *sub = result + subnum * numpts;
         const long long loffset = ii * numpts;
         float *chan = lastdata + loffset + dind;
-// #ifdef _OPENMP
-// #pragma omp parallel for private(jj) shared(sub,chan,numpts)
-// #endif
+/* #ifdef _OPENMP
+   #pragma omp parallel for private(jj) shared(sub,chan,numpts)
+   #endif */
         for (jj = 0; jj < numpts - dind; jj++)
             sub[jj] += chan[jj];
         chan = data + ii * numpts;

--- a/src/downsample.c
+++ b/src/downsample.c
@@ -125,11 +125,9 @@ int main(int argc, char *argv[])
     idata.dt = idata.dt * cmd->factor;
     idata.numonoff = 0;
     idata.N = (double) N;
-    strncpy(idata.name, outname, strlen(outname) - 4);
-    if (useshorts)
-        idata.name[strlen(outname) - 5] = '\0';
-    else
-        idata.name[strlen(outname) - 4] = '\0';
+    size_t namelen = strlen(outname) - (useshorts ? 5 : 4);
+    memcpy(idata.name, outname, namelen);
+    idata.name[namelen] = '\0';
     writeinf(&idata);
 
     fclose(infile);

--- a/src/downsample_cmd.c
+++ b/src/downsample_cmd.c
@@ -742,9 +742,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -358,7 +358,7 @@ char *fitsrhead(char *filename,  /* Name of FITS image file */
         extname[0] = 0;
         hgets(header, "XTENSION", 32, extname);
         if (!strcmp(extname, "IMAGE")) {
-            strncpy(header, "SIMPLE  ", 8);
+            memcpy(header, "SIMPLE  ", 8);
             hputl(header, "SIMPLE", 1);
         }
         hputs(header, "COMMENT", "-------------------------------------------");
@@ -747,7 +747,7 @@ int fitsrthead(char *header,        /* Header for FITS tables file to read */
     int nfields;
     int ifield, ik, ln, i;
     char *h0, *h1, *tf1, *tf2;
-    char tname[12];
+    char tname[16];
     char temp[16];
     char tform[16];
     int tverb;
@@ -806,7 +806,7 @@ int fitsrthead(char *header,        /* Header for FITS tables file to read */
         /* First column of field */
         for (i = 0; i < 12; i++)
             tname[i] = 0;
-        sprintf(tname, "TBCOL%d", ifield + 1);
+        snprintf(tname, sizeof(tname), "TBCOL%d", ifield + 1);
         h1 = ksearch(h0, tname);
         pw[ifield].kf = 0;
         hgeti4(h0, tname, &pw[ifield].kf);
@@ -814,7 +814,7 @@ int fitsrthead(char *header,        /* Header for FITS tables file to read */
         /* Length of field */
         for (i = 0; i < 12; i++)
             tname[i] = 0;
-        sprintf(tname, "TFORM%d", ifield + 1);;
+        snprintf(tname, sizeof(tname), "TFORM%d", ifield + 1);
         tform[0] = 0;
         hgets(h0, tname, 16, tform);
         tf1 = tform + 1;
@@ -826,7 +826,7 @@ int fitsrthead(char *header,        /* Header for FITS tables file to read */
         /* Name of field */
         for (i = 0; i < 12; i++)
             tname[i] = 0;
-        sprintf(tname, "TTYPE%d", ifield + 1);;
+        snprintf(tname, sizeof(tname), "TTYPE%d", ifield + 1);
         temp[0] = 0;
         hgets(h0, tname, 16, temp);
         strcpy(pw[ifield].kname, temp);

--- a/src/hput.c
+++ b/src/hput.c
@@ -138,18 +138,18 @@ int hputnr8(char *hstring,  /* FITS header string */
             double dval)    /* double number */
 {
     char value[30];
-    char format[8];
+    char format[16];
     unsigned int i;
 
     /* Translate value from binary to ASCII */
     if (ndec < 0) {
-        sprintf(format, "%%.%dg", -ndec);
+        snprintf(format, sizeof(format), "%%.%dg", -ndec);
         sprintf(value, format, dval);
         for (i = 0; i < strlen(value); i++)
             if (value[i] == 'e')
                 value[i] = 'E';
     } else {
-        sprintf(format, "%%.%df", ndec);
+        snprintf(format, sizeof(format), "%%.%df", ndec);
         sprintf(value, format, dval);
     }
 
@@ -310,7 +310,7 @@ int hputs(char *hstring,  /* FITS header */
 
     /* Put single quote at start of string */
     value[0] = squot;
-    strncpy(&value[1], cval, lcval);
+    memcpy(&value[1], cval, lcval);
 
     /* If string is less than eight characters, pad it with spaces */
     if (lcval < 8) {
@@ -451,7 +451,7 @@ int hputc(char *hstring,
         *vp = ' ';
 
     /*  Copy keyword to new entry */
-    strncpy(v1, keyword, lkeyword);
+    memcpy(v1, keyword, lkeyword);
 
     /*  Add parameter value in the appropriate place */
     vp = v1 + 8;
@@ -460,14 +460,14 @@ int hputc(char *hstring,
     *vp = ' ';
     vp = vp + 1;
     if (*value == squot) {
-        strncpy(vp, value, lval);
+        memcpy(vp, value, lval);
         if (lval + 12 > 31)
             lc = lval + 12;
         else
             lc = 30;
     } else {
         vp = v1 + 30 - lval;
-        strncpy(vp, value, lval);
+        memcpy(vp, value, lval);
         lc = 30;
     }
 
@@ -478,7 +478,7 @@ int hputc(char *hstring,
         vp = v1 + lc + 2;       /* Jul 16 1997: was vp = v1 + lc * 2 */
         *vp = '/';
         vp = vp + 1;
-        strncpy(vp, newcom, lcom);
+        memcpy(vp, newcom, lcom);
         for (v = vp + lcom; v < v2; v++)
             *v = ' ';
     }
@@ -565,7 +565,7 @@ int hputcom(char *hstring,
         /* If comment will not fit, do not add it */
         if (c0 - v1 > 77)
             return (-1);
-        strncpy(c0, "/ ", 2);
+        memcpy(c0, "/ ", 2);
     }
 
     /* Create new entry */
@@ -573,7 +573,7 @@ int hputcom(char *hstring,
         c1 = c0 + 2;
         if (c1 + lcom > v2)
             lcom = v2 - c1 - 2;
-        strncpy(c1, comment, lcom);
+        memcpy(c1, comment, lcom);
         lblank = v2 - c1 - lcom;
         c1 = c1 + lcom;
         for (i = 0; i < lblank; i++)
@@ -652,7 +652,7 @@ int hadd(char *hplace,  /* FITS header position for new keyword */
 
     /* Cover former first line with new keyword */
     lkey = strlen(keyword);
-    strncpy(hplace, keyword, lkey);
+    memcpy(hplace, keyword, lkey);
     if (lkey < 8) {
         for (i = lkey; i < 8; i++)
             hplace[i] = ' ';
@@ -973,7 +973,7 @@ void deg2str(char *string,  /* Character string (returned) */
              double deg,    /* Angle in degrees */
              int ndec)      /* Number of decimal places in degree string */
 {
-    char degform[8];
+    char degform[32];
     int field;
     char tstring[64];
     double deg1;
@@ -994,10 +994,10 @@ void deg2str(char *string,  /* Character string (returned) */
     /* Write angle to string, adding 4 digits to number of decimal places */
     field = ndec + 4;
     if (ndec > 0) {
-        sprintf(degform, "%%%d.%df", field, ndec);
+        snprintf(degform, sizeof(degform), "%%%d.%df", field, ndec);
         sprintf(tstring, degform, deg1);
     } else {
-        sprintf(degform, "%%%4d", field);
+        snprintf(degform, sizeof(degform), "%%%4d", field);
         sprintf(tstring, degform, (int) deg1);
     }
 
@@ -1019,19 +1019,19 @@ void num2str(char *string,  /* Character string (returned) */
              int field,     /* Number of characters in output field (0=any) */
              int ndec)      /* Number of decimal places in degree string */
 {
-    char numform[8];
+    char numform[32];
 
     if (field > 0) {
         if (ndec > 0) {
-            sprintf(numform, "%%%d.%df", field, ndec);
+            snprintf(numform, sizeof(numform), "%%%d.%df", field, ndec);
             sprintf(string, numform, num);
         } else {
-            sprintf(numform, "%%%dd", field);
+            snprintf(numform, sizeof(numform), "%%%dd", field);
             sprintf(string, numform, (int) num);
         }
     } else {
         if (ndec > 0) {
-            sprintf(numform, "%%.%df", ndec);
+            snprintf(numform, sizeof(numform), "%%.%df", ndec);
             sprintf(string, numform, num);
         } else {
             sprintf(string, "%d", (int) num);

--- a/src/ioinf.c
+++ b/src/ioinf.c
@@ -120,7 +120,7 @@ long chk_str2long(char *instr, char *desc)
 
 void readinf(infodata * data, char *filenm)
 {
-    char tmp1[100], tmp2[100], tmp3[100], *infofilenm, *sptr;
+    char tmp1[100], tmp2[100], tmp3[200], *infofilenm, *sptr;
     int ii, retval, noteslen = 0;
     FILE *infofile;
 

--- a/src/iomak.c
+++ b/src/iomak.c
@@ -213,7 +213,7 @@ void read_mak_file(char basefilenm[], makedata * mdata)
 /* Read the data for makedata from the makefile. */
 {
     FILE *makefile;
-    char makefilenm[200], tmp[50];
+    char makefilenm[205], tmp[50];
     double tmponoff[40];
     int i;
 
@@ -376,7 +376,7 @@ void write_mak_file(makedata * mdata)
 /* Write the data for makedata to the makefile.  */
 {
     FILE *makefile;
-    char makefilenm[200];
+    char makefilenm[205];
     int i;
 
     sprintf(makefilenm, "%s.mak", mdata->basefilenm);

--- a/src/makedata.c
+++ b/src/makedata.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     setsd(s1, s2);
 
     /* Initialization strings */
-    char datafilenm[200], infofilenm[200];
+    char datafilenm[205], infofilenm[205];
     FILE *datfile;
 
     /* For binary orbit integration */

--- a/src/misc_utils.c
+++ b/src/misc_utils.c
@@ -144,9 +144,7 @@ int split_root_suffix(char *input, char **root, char **suffix)
     sptr = strrchr(input, '.');
     if (sptr == NULL) {
         *root = (char *) calloc(len + 1, sizeof(char));
-        strncpy(*root, input, len);
-        // ensure null-terminated
-        (*root)[len] = '\0';
+        strncpy(*root, input, len + 1);
         return 0;
     } else {
         rootlen = sptr - input;

--- a/src/mpiprepsubband_cmd.c
+++ b/src/mpiprepsubband_cmd.c
@@ -789,8 +789,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/prepdata_cmd.c
+++ b/src/prepdata_cmd.c
@@ -775,8 +775,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/prepfold.c
+++ b/src/prepfold.c
@@ -611,7 +611,8 @@ int main(int argc, char *argv[])
         (idata.bary && cmd->barypolycosP)) {
         char *polycofilenm;
         polycofilenm = (char *) calloc(strlen(outfilenm) + 9, sizeof(char));
-        sprintf(polycofilenm, "%s.polycos", outfilenm);
+        strcpy(polycofilenm, outfilenm);
+        strcat(polycofilenm, ".polycos");
         cmd->psrnameP = 1;
         if (cmd->timingP)
             cmd->psrname = make_polycos(cmd->timing, &idata, polycofilenm, cmd->debugP);

--- a/src/prepfold_cmd.c
+++ b/src/prepfold_cmd.c
@@ -941,8 +941,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/prepsubband_cmd.c
+++ b/src/prepsubband_cmd.c
@@ -803,8 +803,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/readfile_cmd.c
+++ b/src/readfile_cmd.c
@@ -796,9 +796,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/realfft_cmd.c
+++ b/src/realfft_cmd.c
@@ -745,9 +745,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/rednoise_cmd.c
+++ b/src/rednoise_cmd.c
@@ -739,9 +739,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/rfifind.c
+++ b/src/rfifind.c
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
 
         {
             printf("Generating FFT plan...\n\n");
-            float *chandata = NULL, powavg, powstd, powmax;
+            float *chandata = NULL;
             chandata = gen_fvect(ptsperint);
 
             fcomplex *fftdata = gen_cvect((ptsperint / 2) + 1);

--- a/src/rfifind_cmd.c
+++ b/src/rfifind_cmd.c
@@ -797,8 +797,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/rzinterp.c
+++ b/src/rzinterp.c
@@ -200,7 +200,7 @@ void rz_interp(fcomplex * data, long numdata, double r, double z,
 
     lodata = intfreq - kern_half_width;
     if (lodata < 0) {
-        loresp = abs(lodata);
+        loresp = labs(lodata);
         lodata = 0;
     } else {
         loresp = 0;

--- a/src/rzwinterp.c
+++ b/src/rzwinterp.c
@@ -193,7 +193,7 @@ void rzw_interp(fcomplex * data, long numdata, double r, double z,
 
     lodata = intfreq - kern_half_width;
     if (lodata < 0) {
-        loresp = abs(lodata);
+        loresp = labs(lodata);
         lodata = 0;
     } else {
         loresp = 0;

--- a/src/search_bin.c
+++ b/src/search_bin.c
@@ -368,7 +368,7 @@ int main(int argc, char *argv[])
 
     notes = malloc(sizeof(char) * newncand * 18 + 1);
     for (ii = 0; ii < newncand; ii++)
-        strncpy(notes + ii * 18, "                     ", 18);
+        memset(notes + ii * 18, ' ', 18);
 
     /* Check the database for possible known PSR detections */
 

--- a/src/search_bin_cmd.c
+++ b/src/search_bin_cmd.c
@@ -779,9 +779,18 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);

--- a/src/show_pfd_cmd.c
+++ b/src/show_pfd_cmd.c
@@ -731,8 +731,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/spigot.c
+++ b/src/spigot.c
@@ -206,11 +206,11 @@ int read_SPIGOT_header(char *filename, SPIGOT_INFO * spigot)
     /* Set the lag scaling and offset values if this is the firsttime */
     if (firsttime) {
         int NomOffset = 0, ii;
-        char keyword[10], ctmp[100];
+        char keyword[15], ctmp[100];
         float ftmp1, ftmp2;
 
         for (ii = 0; ii < spigot->lags_per_sample; ii++) {
-            sprintf(keyword, "LAGD%04d", ii);
+            snprintf(keyword, sizeof(keyword), "LAGD%04d", ii);
             hgets(hdr, keyword, 100, ctmp);
             sscanf(ctmp, "%f %f %f %f", lag_factor + ii, lag_offset + ii, &ftmp1,
                    &ftmp2);
@@ -295,7 +295,7 @@ void SPIGOT_INFO_to_inf(SPIGOT_INFO * spigot, infodata * idata)
     char ctmp[100];
     struct passwd *pwd;
 
-    strncpy(idata->object, spigot->object, 24);
+    strcpy(idata->object, spigot->object);
     hours2hms(spigot->ra / 15.0, &(idata->ra_h), &(idata->ra_m), &(idata->ra_s));
     deg2dms(spigot->dec, &(idata->dec_d), &(idata->dec_m), &(idata->dec_s));
     strcpy(idata->telescope, "GBT");
@@ -320,7 +320,7 @@ void SPIGOT_INFO_to_inf(SPIGOT_INFO * spigot, infodata * idata)
     // strcpy(idata->analyzer, getlogin());
     pwd = getpwuid(geteuid());
     strcpy(idata->analyzer, pwd->pw_name);
-    strncpy(idata->observer, spigot->observer, 24);
+    strcpy(idata->observer, spigot->observer);
     if (spigot->summed_pols)
         sprintf(ctmp,
                 "%d IF(s) were summed.  Lags are %d bit ints.",

--- a/src/split_parkes_beams.c
+++ b/src/split_parkes_beams.c
@@ -20,7 +20,7 @@ int split_root_suffix(char *input, char **root, char **suffix)
     sptr = strrchr(input, '.');
     if (sptr == NULL) {
         *root = (char *) calloc(len + 1, sizeof(char));
-        strncpy(*root, input, len);
+        strncpy(*root, input, len + 1);
         return 0;
     } else {
         rootlen = sptr - input;

--- a/src/toas2dat_cmd.c
+++ b/src/toas2dat_cmd.c
@@ -731,8 +731,17 @@ catArgv(int argc, char **argv)
   size_t l;
   char *s, *t;
 
+  if( argc == 0 ) {
+    s = (char *)malloc(1);
+    if( !s ) {
+      fprintf(stderr, "%s: out of memory\n", Program);
+      exit(EXIT_FAILURE);
+    }
+    *s = '\0';
+    return s;
+  }
   for(i=0, l=0; i<argc; i++) l += (1+strlen(argv[i]));
-  s = (char *)malloc(l);
+  s = (char *)malloc(l + 1);
   if( !s ) {
     fprintf(stderr, "%s: out of memory\n", Program);
     exit(EXIT_FAILURE);

--- a/src/wapp_head_parse.c
+++ b/src/wapp_head_parse.c
@@ -12,6 +12,7 @@ void head_input(char *, int *, int);
 int linecount = 1;
 
 #define YY_INPUT(buf,result,max) head_input(buf,&result,max)
+#define YY_NO_INPUT
 
 void ignore()
 {

--- a/src/zapbirds_cmd.c
+++ b/src/zapbirds_cmd.c
@@ -745,9 +745,19 @@ static char *catArgv(int argc, char **argv)
     size_t l;
     char *s, *t;
 
+    if (argc == 0) {
+        s = (char *) malloc(1);
+        if (!s) {
+            fprintf(stderr, "%s: out of memory\n", Program);
+            exit(EXIT_FAILURE);
+        }
+        *s = '\0';
+        return s;
+    }
+
     for (i = 0, l = 0; i < argc; i++)
         l += (1 + strlen(argv[i]));
-    s = (char *) malloc(l);
+    s = (char *) malloc(l + 1);
     if (!s) {
         fprintf(stderr, "%s: out of memory\n", Program);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
- Buffer Overflow/Truncation Warnings: Enlarged fixed buffers and switched `sprintf` to `snprintf`:`cand_output.c`, `fitsfile.c`, `hput.c`, `ioinf.c`, `iomak.c`, `makedata.c`, `spigot.c`.
- `strncpy` Truncation Warnings: Replaced with `memcpy`/`memset`/`strcpy`/`strcpy`+`strcat` with explicit null-termination, keeping the same output:`accel_utils.c`, `bincand.c`, `database.c`, `downsample.c`, `fitsfile.c`, `hput.c`, `misc_utils.c`, `prepfold.c`, `search_bin.c`, `split_parkes_beams.c`.
- Type Warnings: Changed `abs` to `labs` for `long` arguments (`rzinterp.c`, `rzwinterp.c`); made the static `num[]` lookup table `const char *const` (`database.c`); zero-initialized `bestorb` and used `strncmp` for a bounded compare (`bincand.c`).
- Unused Variables: Removed a redundant `gen_cvect` allocation pair in `accel_utils.c`, dropped unused locals in `rfifind.c`, and added `#define YY_NO_INPUT` in `wapp_head_parse.c`.
- Multi-Line Comment Warning: Converted `//` comments to block comments in `dispersion.c`.
- `catArgv` Allocation Warning: In the `clig`-generated command parsers — added an `argc == 0` guard and bumped `malloc(l)` to `malloc(l + 1)`: `*_cmd.c`.